### PR TITLE
return the resource with the same persistence in cache

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -81,7 +81,9 @@ module CachedResource
       # The key is processed to make sure it is valid.
       def cache_read(key)
         key = cache_key(Array(key)) unless key.is_a? String
-        object = cached_resource.cache.read(key).try(:dup)
+        object = cached_resource.cache.read(key).try do |cache|
+          cache.dup.tap { |o| o.instance_variable_set(:@persisted, cache.persisted?) if cache.respond_to?(:persisted?)}
+        end
         object && cached_resource.logger.info("#{CachedResource::Configuration::LOGGER_PREFIX} READ #{key}")
         object
       end

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -40,6 +40,12 @@ describe CachedResource do
       Thing.cached_resource.cache.read("thing/1").should == result
     end
 
+    it "should cache a response with the same persistence" do
+      result1 = Thing.find(1)
+      result2 = Thing.find(1)
+      result1.persisted?.should == result2.persisted?
+    end
+
     it "should read a response when the request is made again" do
       # make a request
       Thing.find(1)


### PR DESCRIPTION
The returned cache version of the AR object seems not keep the @persisted attribute, this somehow cause a weird routing issue in rails 3.1.1 (We used this in a real world application, haven't tested in other versions of rails though).

A contrived example is user_path(current_user) will work perfectly if current_user returns a object with persisted? true, but will fail with no routing match error if persisted? false.  That's why we want to keep the persisted? attribute.
