### PR TITLE
Disallow spaces in generated keys

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -110,7 +110,7 @@ module CachedResource
 
       # Generate the request cache key.
       def cache_key(*arguments)
-        "#{name.parameterize.gsub("-", "/")}/#{arguments.join('/')}".downcase
+        "#{name.parameterize.gsub("-", "/")}/#{arguments.join('/')}".downcase.delete(' ')
       end
 
       # Make a full duplicate of an ActiveResource record.

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -36,6 +36,7 @@ describe CachedResource do
       ActiveResource::HttpMock.reset!
       ActiveResource::HttpMock.respond_to do |mock|
         mock.get "/things/1.json", {}, @thing_json
+        mock.get "/things/1.json?foo=bar", {}, @thing_json
         mock.get "/things/fded.json", {}, @string_thing_json
       end
     end
@@ -48,6 +49,11 @@ describe CachedResource do
     it "should cache a response for a string primary key" do
       result = Thing.find("fded")
       Thing.cached_resource.cache.read("thing/fded").should == result
+    end
+
+    it "should cache without whitespace in keys" do
+      result = Thing.find(1, :from => 'path', :params => { :foo => 'bar' })
+      Thing.cached_resource.cache.read('thing/1/{:from=>"path",:params=>{:foo=>"bar"}}').should == result
     end
 
     it "should empty the cache when clear_cache is called" do


### PR DESCRIPTION
A find call like that illustrated in the spec in this commit would result in a key containing spaces, which is invalid for memcached with ASCII protocol.

More sanitization might be warranted: at least newlines, carriage returns and null bytes are invalid, I believe, but these seem unlikely to pop up from Ruby's *args.to_s...
