### PR TITLE
fix `uninitialized constant ActiveResource` in rails 4.0.3

### DIFF
--- a/lib/cached_resource.rb
+++ b/lib/cached_resource.rb
@@ -6,6 +6,7 @@ require 'cached_resource/cached_resource'
 require 'cached_resource/configuration'
 require 'cached_resource/caching'
 require 'cached_resource/version'
+require 'active_resource'
 
 module CachedResource
   # nada


### PR DESCRIPTION
add require active_resource to fix uninitialized constant ActiveResource in rails 4.0.3
