### PR TITLE
store objects as json in cache to avoid undefined class/module on relations

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -83,7 +83,8 @@ module CachedResource
 
       # Read a entry from the cache for the given key.
       def cache_read(key)
-        object = cached_resource.cache.read(key).try do |cache|
+        object = cached_resource.cache.read(key).try do |json_cache|
+          cache = json_to_object(JSON.parse(json_cache))
           if cache.is_a? Enumerable
             restored = cache.map { |record| full_dup(record) }
             next restored unless respond_to?(:collection_parser)
@@ -98,7 +99,7 @@ module CachedResource
 
       # Write an entry to the cache for the given key and value.
       def cache_write(key, object)
-        result = cached_resource.cache.write(key, object, :expires_in => cached_resource.generate_ttl)
+        result = cached_resource.cache.write(key, object.to_json, :expires_in => cached_resource.generate_ttl)
         result && cached_resource.logger.info("#{CachedResource::Configuration::LOGGER_PREFIX} WRITE #{key}")
         result
       end
@@ -120,6 +121,14 @@ module CachedResource
       def full_dup(record)
         record.dup.tap do |o|
           o.instance_variable_set(:@persisted, record.persisted?)
+        end
+      end
+
+      def json_to_object(json)
+        if json.is_a? Array
+          json.map { |attrs| self.new(attrs) }
+        else
+          self.new(json)
         end
       end
 


### PR DESCRIPTION
Active resource create new clases for each of the different relations that a model has.
When you cache an object and then try to read it after reloading the app the new class does not exist, thats why we get the undefined class/module

One approach is to define the relation classes yourself, but we can let ActiveResource handle it passing it the stored json.

this is related to the issue #6
