### PR TITLE
hash long cache keys

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -112,7 +112,10 @@ module CachedResource
 
       # Generate the request cache key.
       def cache_key(*arguments)
-        "#{name.parameterize.gsub("-", "/")}/#{arguments.join('/')}".downcase.delete(' ')
+        arguments_string = arguments.join('/')
+        arguments_key = arguments_string.length > 150 ? Digest::SHA2.hexdigest(arguments_string) : arguments_string
+
+        "#{name.parameterize.gsub("-", "/")}/#{arguments_key}".downcase.delete(' ')
       end
 
       # Make a full duplicate of an ActiveResource record.

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -56,6 +56,14 @@ describe CachedResource do
       Thing.cached_resource.cache.read('thing/1/{:from=>"path",:params=>{:foo=>"bar"}}').should == result
     end
 
+    it "should hash long parameters in cache key" do
+      params = [1, {long_params: "l" * Thing::MAX_ARGUMENTS_CACHE_SIZE }]
+      hash_params = Thing.send(:hash_string, params.join("/"))
+
+      result = Thing.find(*params)
+      Thing.cached_resource.cache.read("thing/#{hash_params}").should == result
+    end
+
     it "should empty the cache when clear_cache is called" do
       result = Thing.find(1)
       Thing.clear_cache
@@ -510,4 +518,5 @@ describe CachedResource do
       new_result.name.should_not == old_result.name
     end
   end
+
 end


### PR DESCRIPTION
Some cache stores have a size limit for the keys. E.g ActiveSupport::Cache::FileStore
So in case there are a lot of parameters and the cache key is too long we hash it
