### PR TITLE
Feature/race condition ttl configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ CachedResource accepts the following options:
 
 * `:enabled` Default: `true`
 * `:ttl` The time in seconds until the cache should expire. Default: `604800`
+* `:race_condition_ttl` The race condition ttl, to prevent `dog pile effect(https://en.wikipedia.org/wiki/Cache_stampede)` or `cache stampede(https://en.wikipedia.org/wiki/Cache_stampede)`. Default: 86400
 * `:ttl_randomization` Enable ttl randomization. Default: `false`
 * `:ttl_randomization_scale` A Range from which a random value will be selected to scale the ttl. Default: `1..2`
 * `:collection_synchronize` Use collections to generate cache entries for individuals.  Update the existing cached principal collection when retrieving subsets of the principal collection or individuals.  Default: `false`

--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -98,7 +98,7 @@ module CachedResource
 
       # Write an entry to the cache for the given key and value.
       def cache_write(key, object)
-        result = cached_resource.cache.write(key, object, :expires_in => cached_resource.generate_ttl)
+        result = cached_resource.cache.write(key, object, :race_condition_ttl => cached_resource.race_condition_ttl, :expires_in => cached_resource.generate_ttl)
         result && cached_resource.logger.info("#{CachedResource::Configuration::LOGGER_PREFIX} WRITE #{key}")
         result
       end

--- a/lib/cached_resource/configuration.rb
+++ b/lib/cached_resource/configuration.rb
@@ -29,6 +29,7 @@ module CachedResource
     def initialize(options={})
       super({
         :enabled => true,
+        :race_condition_ttl => 604800,
         :ttl => 604800,
         :ttl_randomization => false,
         :ttl_randomization_scale => 1..2,

--- a/lib/cached_resource/configuration.rb
+++ b/lib/cached_resource/configuration.rb
@@ -20,6 +20,7 @@ module CachedResource
     # defaults. The following options exist for cached resource:
     # :enabled, default: true
     # :ttl, default: 604800
+    # :race_condition_ttl: 86400
     # :ttl_randomization, default: false,
     # :ttl_randomization_scale, default: 1..2,
     # :collection_synchronize, default: false,

--- a/lib/cached_resource/configuration.rb
+++ b/lib/cached_resource/configuration.rb
@@ -29,7 +29,7 @@ module CachedResource
     def initialize(options={})
       super({
         :enabled => true,
-        :race_condition_ttl => 604800,
+        :race_condition_ttl => 86400,
         :ttl => 604800,
         :ttl_randomization => false,
         :ttl_randomization_scale => 1..2,

--- a/lib/cached_resource/version.rb
+++ b/lib/cached_resource/version.rb
@@ -1,3 +1,3 @@
 module CachedResource
-  VERSION = "4.1.0"
+  VERSION = "4.2.0"
 end

--- a/spec/cached_resource/configuration_spec.rb
+++ b/spec/cached_resource/configuration_spec.rb
@@ -66,6 +66,7 @@ describe "CachedResource::Configuration" do
     before(:each) do
       class Foo < ActiveResource::Base
         cached_resource :ttl => 1,
+                        :race_condition_ttl => 5,
                         :cache => "cache",
                         :logger => "logger",
                         :enabled => false,
@@ -82,6 +83,7 @@ describe "CachedResource::Configuration" do
     it "should relfect the specified options" do
       cr = Foo.cached_resource
       cr.ttl.should == 1
+      expect(cr.race_condition_ttl).to eq(5)
       cr.cache.should == "cache"
       cr.logger.should == "logger"
       cr.enabled.should == false
@@ -122,6 +124,7 @@ describe "CachedResource::Configuration" do
     before(:each) do
       class Bar < ActiveResource::Base
         cached_resource :ttl => 1,
+                        :race_condition_ttl => 5,
                         :cache => "cache",
                         :logger => "logger",
                         :enabled => false,
@@ -149,6 +152,7 @@ describe "CachedResource::Configuration" do
     before(:each) do
       class Bar < ActiveResource::Base
         cached_resource :ttl => 1,
+                        :race_condition_ttl => 5,
                         :cache => "cache",
                         :logger => "logger",
                         :enabled => false,
@@ -182,6 +186,7 @@ describe "CachedResource::Configuration" do
       cr.custom.should == nil
       cr.ttl_randomization.should == false
       cr.ttl_randomization_scale.should == (1..2)
+      expect(cr.race_condition_ttl).to eq(5)
     end
 
   end

--- a/spec/cached_resource/configuration_spec.rb
+++ b/spec/cached_resource/configuration_spec.rb
@@ -186,7 +186,7 @@ describe "CachedResource::Configuration" do
       cr.custom.should == nil
       cr.ttl_randomization.should == false
       cr.ttl_randomization_scale.should == (1..2)
-      expect(cr.race_condition_ttl).to eq(5)
+      expect(cr.race_condition_ttl).to eq(86400)
     end
 
   end


### PR DESCRIPTION
adding race_condition_ttl params
when writing to cache

reduce dog pile effect