### PR TITLE
Cache in json

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -135,6 +135,10 @@ module CachedResource
 
       def preserve_prefix_options(object)
         if object.is_a? ActiveResource::Collection
+          object.elements = object.map do |item|
+            self.new(item.attributes.merge!(item.prefix_options))
+          end
+        elsif object.is_a? Array
           object.map do |item|
             self.new(item.attributes.merge!(item.prefix_options))
           end

--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -99,6 +99,7 @@ module CachedResource
 
       # Write an entry to the cache for the given key and value.
       def cache_write(key, object)
+        preserve_prefix_options(object)
         result = cached_resource.cache.write(key, object.to_json, :race_condition_ttl => cached_resource.race_condition_ttl, :expires_in => cached_resource.generate_ttl)
         result && cached_resource.logger.info("#{CachedResource::Configuration::LOGGER_PREFIX} WRITE #{key}")
         result
@@ -129,6 +130,16 @@ module CachedResource
           json.map { |attrs| self.new(attrs) }
         else
           self.new(json)
+        end
+      end
+
+      def preserve_prefix_options(object)
+        if object.is_a? ActiveResource::Collection
+          object.map do |item|
+            self.new(item.attributes.merge!(item.prefix_options))
+          end
+        else
+          self.new(object.attributes.merge(object.prefix_options))
         end
       end
 

--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -83,7 +83,8 @@ module CachedResource
 
       # Read a entry from the cache for the given key.
       def cache_read(key)
-        object = cached_resource.cache.read(key).try do |cache|
+        object = cached_resource.cache.read(key).try do |json_cache|
+          cache = json_to_object(JSON.parse(json_cache))
           if cache.is_a? Enumerable
             restored = cache.map { |record| full_dup(record) }
             next restored unless respond_to?(:collection_parser)
@@ -98,7 +99,7 @@ module CachedResource
 
       # Write an entry to the cache for the given key and value.
       def cache_write(key, object)
-        result = cached_resource.cache.write(key, object, :expires_in => cached_resource.generate_ttl)
+        result = cached_resource.cache.write(key, object.to_json, :expires_in => cached_resource.generate_ttl)
         result && cached_resource.logger.info("#{CachedResource::Configuration::LOGGER_PREFIX} WRITE #{key}")
         result
       end
@@ -120,6 +121,14 @@ module CachedResource
       def full_dup(record)
         record.dup.tap do |o|
           o.instance_variable_set(:@persisted, record.persisted?)
+        end
+      end
+
+      def json_to_object(json)
+        if json.is_a? Array
+          json.map { |attrs| self.new(attrs) }
+        else
+          self.new(json)
         end
       end
 

--- a/lib/cached_resource/version.rb
+++ b/lib/cached_resource/version.rb
@@ -1,3 +1,3 @@
 module CachedResource
-  VERSION = "4.2.0"
+  VERSION = "4.2.1"
 end


### PR DESCRIPTION
Based on @Adrian2112 changes

Enable better handling of prefix_options as the fetch object removes it from the object. 

Eliminate the following error, due to object serialization and deserialization when going into the cache.  
Unexpected exception during Dalli request: NameError: uninitialized constant
https://github.com/petergoldstein/dalli/issues/374 