### PR TITLE
Remove alias_method_chain.

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -6,7 +6,8 @@ module CachedResource
 
     included do
       class << self
-        alias_method_chain :find, :cache
+        alias_method :find_without_cache, :find
+        alias_method :find, :find_with_cache      
       end
     end
 


### PR DESCRIPTION
Rails 5 support

See deprecation of alias_method_chain in https://github.com/rails/rails/pull/19434

- Sorry, this is a bit hack & slash, does not increment version etc.