### PR TITLE
Use ActiveSupport::JSON.decode to parse from cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: ruby
 sudo: false
+before_install:
+  - gem install bundler:1.17.3
 cache: bundler
 
 rvm:

--- a/gemfiles/4.2.gemfile.lock
+++ b/gemfiles/4.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cached_resource (5.1.1)
+    cached_resource (5.1.2)
       activeresource (>= 4.0)
       activesupport (>= 4.0)
       nilio (>= 1.0)
@@ -93,7 +93,7 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails-observers (0.1.4)
+    rails-observers (0.1.5)
       activemodel (>= 4.0)
     railties (4.2.9)
       actionpack (= 4.2.9)
@@ -137,4 +137,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/gemfiles/5.0.gemfile.lock
+++ b/gemfiles/5.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cached_resource (5.1.1)
+    cached_resource (5.1.2)
       activeresource (>= 4.0)
       activesupport (>= 4.0)
       nilio (>= 1.0)
@@ -37,19 +37,18 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.0.2)
       activesupport (= 5.0.2)
-    activemodel-serializers-xml (1.0.1)
+    activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
-      activerecord (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
     activerecord (5.0.2)
       activemodel (= 5.0.2)
       activesupport (= 5.0.2)
       arel (~> 7.0)
-    activeresource (5.0.0)
-      activemodel (>= 5.0, < 6)
+    activeresource (5.1.1)
+      activemodel (>= 5.0, < 7)
       activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 5.0, < 6)
+      activesupport (>= 5.0, < 7)
     activesupport (5.0.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -147,4 +146,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/gemfiles/5.1.gemfile.lock
+++ b/gemfiles/5.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    cached_resource (5.1.1)
+    cached_resource (5.1.2)
       activeresource (>= 4.0)
       activesupport (>= 4.0)
       nilio (>= 1.0)
@@ -37,19 +37,18 @@ GEM
       globalid (>= 0.3.6)
     activemodel (5.1.2)
       activesupport (= 5.1.2)
-    activemodel-serializers-xml (1.0.1)
+    activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
-      activerecord (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
     activerecord (5.1.2)
       activemodel (= 5.1.2)
       activesupport (= 5.1.2)
       arel (~> 8.0)
-    activeresource (5.0.0)
-      activemodel (>= 5.0, < 6)
+    activeresource (5.1.1)
+      activemodel (>= 5.0, < 7)
       activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 5.0, < 6)
+      activesupport (>= 5.0, < 7)
     activesupport (5.1.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (~> 0.7)
@@ -147,4 +146,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -86,8 +86,7 @@ module CachedResource
       def cache_read(key)
         object = cached_resource.cache.read(key).try do |json_cache|
 
-          # In older version JSON can't deserialize 'null' to nil
-          json = json_cache == 'null' ? nil : JSON.parse(json_cache, :symbolize_names => true)
+          json = ActiveSupport::JSON.decode(json_cache)
 
           unless json.nil?
             cache = json_to_object(json)
@@ -134,9 +133,9 @@ module CachedResource
       def json_to_object(json)
         if json.is_a? Array
           json.map { |attrs|
-            self.new(attrs[:object], attrs[:persistence]) }
+            self.new(attrs["object"], attrs["persistence"]) }
         else
-          self.new(json[:object], json[:persistence])
+          self.new(json["object"], json["persistence"])
         end
       end
 


### PR DESCRIPTION
Under the hood, [ActiveResource uses `ActiveSupport::JSON.decode`](https://github.com/rails/activeresource/blob/dedecf90996622776b7aa0e54957ffc8fb3ac2f9/lib/active_resource/base.rb#L1099) to parse JSON. Unlike `JSON.parse`, `ActiveSupport::JSON.decode` will convert any strings it recognizes as dates/times into their corresponding objects if `ActiveSupport.parse_json_times` is enabled. [Ref.](https://api.rubyonrails.org/classes/ActiveSupport/JSON.html#method-c-decode)

Thus currently if `ActiveSupport.parse_json_times` is enabled, the data returned from cache is inconsistent with what is returned from ActiveResource directly. This change fixes the inconsistency by also using `ActiveSupport::JSON.decode` to parse the JSON from cache.