### PR TITLE
Add option to not cache collections

### DIFF
--- a/lib/cached_resource/configuration.rb
+++ b/lib/cached_resource/configuration.rb
@@ -22,7 +22,8 @@ module CachedResource
     # :collection_synchronize, default: false,
     # :collection_arguments, default: [:all]
     # :cache, default: Rails.cache or ActiveSupport::Cache::MemoryStore.new,
-    # :logger, default: Rails.logger or ActiveSupport::Logger.new(NilIO.new)
+    # :logger, default: Rails.logger or ActiveSupport::Logger.new(NilIO.new),
+    # :cache_collections, default: true
     def initialize(options={})
       super({
         :enabled => true,
@@ -33,7 +34,8 @@ module CachedResource
         :collection_synchronize => false,
         :collection_arguments => [:all],
         :cache => defined?(Rails.cache)  && Rails.cache || CACHE,
-        :logger => defined?(Rails.logger) && Rails.logger || LOGGER
+        :logger => defined?(Rails.logger) && Rails.logger || LOGGER,
+        :cache_collections => true
       }.merge(options))
     end
 

--- a/spec/cached_resource/configuration_spec.rb
+++ b/spec/cached_resource/configuration_spec.rb
@@ -22,6 +22,10 @@ describe "CachedResource::Configuration" do
       configuration.collection_arguments.should == [:all]
     end
 
+    it "should cache collections" do
+      configuration.cache_collections == true
+    end
+
     describe "outside a Rails environment" do
       it "should be logging to a buffered logger attached to a NilIO" do
         configuration.logger.class.should == default_logger
@@ -72,7 +76,8 @@ describe "CachedResource::Configuration" do
                         :enabled => false,
                         :collection_synchronize => true,
                         :collection_arguments => [:every],
-                        :custom => "irrelevant"
+                        :custom => "irrelevant",
+                        :cache_collections => true
       end
     end
 
@@ -90,6 +95,7 @@ describe "CachedResource::Configuration" do
       cr.collection_synchronize.should == true
       cr.collection_arguments.should == [:every]
       cr.custom.should == "irrelevant"
+      cr.cache_collections.should == true
     end
   end
 
@@ -130,7 +136,8 @@ describe "CachedResource::Configuration" do
                         :enabled => false,
                         :collection_synchronize => true,
                         :collection_arguments => [:every],
-                        :custom => "irrelevant"
+                        :custom => "irrelevant",
+                        :cache_collections => true
       end
 
       class Foo < Bar
@@ -158,7 +165,8 @@ describe "CachedResource::Configuration" do
                         :enabled => false,
                         :collection_synchronize => true,
                         :collection_arguments => [:every],
-                        :custom => "irrelevant"
+                        :custom => "irrelevant",
+                        :cache_collections => true
       end
 
       class Foo < Bar
@@ -186,6 +194,7 @@ describe "CachedResource::Configuration" do
       cr.custom.should == nil
       cr.ttl_randomization.should == false
       cr.ttl_randomization_scale.should == (1..2)
+      cr.cache_collections.should == true
       expect(cr.race_condition_ttl).to eq(86400)
     end
 


### PR DESCRIPTION
Adds a configuration option to cache only individual records.

Useful when Things are created often but not updated often/even.

Input on the is_any_collection? method is welcomed, I wasn't quite sure.

I also avoid writing to cache and retrieving it to avoid the overhead.