### PR TITLE
[ISSUE-57] Fixes bug where CollectionParser is not chainable

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -37,10 +37,11 @@ module CachedResource
         cache_read(key) || find_via_reload(key, *arguments)
       end
 
-      # Re/send the request to fetch the resource. Cache the response
-      # for the request.
+      # Re/send the request to fetch the resource
       def find_via_reload(key, *arguments)
         object = find_without_cache(*arguments)
+        return object unless cached_resource.enabled
+
         cache_collection_synchronize(object, *arguments) if cached_resource.collection_synchronize
         return object if !cached_resource.cache_collections && is_any_collection?(*arguments)
         cache_write(key, object)

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -505,14 +505,9 @@ describe CachedResource do
       end
     end
 
-    it "should cache a response" do
+    it "should not cache a response" do
       result = Thing.find(1)
-      read_from_cache("thing/1").should == result
-    end
-
-    it "should cache a response for a string primary key" do
-      result = Thing.find("fded")
-      read_from_cache("thing/fded").should == result
+      read_from_cache("thing/1").should be_nil
     end
 
     it "should always remake the request" do
@@ -527,42 +522,6 @@ describe CachedResource do
       ActiveResource::HttpMock.requests.length.should == 1
       Thing.find("fded")
       ActiveResource::HttpMock.requests.length.should == 2
-    end
-
-    it "should rewrite the cache for each request" do
-      Thing.find(1)
-      old_result = read_from_cache("thing/1")
-
-      # change the response
-      ActiveResource::HttpMock.reset!
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/things/1.json", {}, @other_thing_json
-      end
-
-      Thing.find(1)
-      new_result = read_from_cache("thing/1")
-      # since active resources are equal if and only if they
-      # are the same object or an instance of the same class,
-      # not new?, and have the same id.
-      new_result.name.should_not == old_result.name
-    end
-
-    it "should rewrite the cache for each request for a string primary key" do
-      Thing.find("fded")
-      old_result = read_from_cache("thing/fded")
-
-      # change the response
-      ActiveResource::HttpMock.reset!
-      ActiveResource::HttpMock.respond_to do |mock|
-        mock.get "/things/fded.json", {}, @other_string_thing_json
-      end
-
-      Thing.find("fded")
-      new_result = read_from_cache("thing/fded")
-      # since active resources are equal if and only if they
-      # are the same object or an instance of the same class,
-      # not new?, and have the same id.
-      new_result.name.should_not == old_result.name
     end
   end
 


### PR DESCRIPTION
## Summary
1. Change the structure of value saved in cache
    - Adds original params and prefix options (incase it is needed in near future)
2. Taps into object and assigns original params

Fixes: 
- https://github.com/mhgbrown/cached_resource/issues/56 (Pulled from https://github.com/mhgbrown/cached_resource/pull/58)
- https://github.com/mhgbrown/cached_resource/issues/57 



<img width="805" alt="2024-01-10_15-20-17" src="https://github.com/mhgbrown/cached_resource/assets/15808412/68d7d8c9-cbb5-443a-9508-81c5d185892a">
