### PR TITLE
[ISSUE-57] fix incompatability with rails/activesupport 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ CachedResource is designed to be framework agnostic, but will hook into Rails fo
 | 💎 3.1   |     |     |     | ✅   | ✅   | ✅   |
 | 💎 3.2   |     |     |     | ✅   | ✅   | ✅   |
 
+## Limitations
+
+The following are limitations for ActiveResource/Rails versions
+
+| ActiveSupport Version |                             Limitation                                  |
+|---------------------- | ----------------------------------------------------------------------- |
+| 🛤️ 4.X                |  You cannot chain calls. Ie `Thing.where(fn: 'foo').where(ln: 'bar')`. <br> However, you can still access `original_params` and the `resource_class` and replicate it with <br>`call1 = Thing.where(fn: 'foo')`<br>`call1.resource_class.where(call1.original_params.merge(ln: 'bar'))`  |
 
 ## Configuration
 

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -234,14 +234,21 @@ describe CachedResource do
           cached = read_from_cache('thing/all/{:params=>{:name=>"ada"}}')
           cached.should be_instance_of(CustomCollection)
           cached.original_params.should == { 'name' => 'ada' }
+          cached.resource_class.should == Thing
           cached.map(&:id).should == @thing_collection.map { |h| h[:id]}
 
-          non_cached = cached.where(major: 'CS')
-          non_cached.original_params.should == { 'name' => 'ada', 'major' => 'CS' }
-          non_cached.map(&:id).should == @thing_collection2.map { |h| h[:id]}
+          if ActiveResource::VERSION::MAJOR < 5
+            non_cached = cached.resource_class.where(cached.original_params.merge(major: 'CS'))
+          else
+            non_cached = cached.where(major: 'CS')
+          end
 
+          non_cached.original_params.should == { 'name' => 'ada', 'major' => 'CS' }
+          non_cached.resource_class.should == Thing
+          non_cached.map(&:id).should == @thing_collection2.map { |h| h[:id]}
           cached = read_from_cache('thing/all/{:params=>{"name"=>"ada",:major=>"cs"}}')
           cached.original_params.should == { 'name' => 'ada', 'major' => 'CS' }
+          cached.resource_class.should == Thing
           cached.map(&:id).should == @thing_collection2.map { |h| h[:id]}
         end
       else


### PR DESCRIPTION
## Summary
Context: Continuation of https://github.com/mhgbrown/cached_resource/issues/57
Adds specs for `ActiveSupport` and `ActiveResource` 4.x. Updates README to reflect changes.