### PR TITLE
[ISSUE-62]: Avoid cache nil or empty array responses

### DIFF
--- a/lib/cached_resource/caching.rb
+++ b/lib/cached_resource/caching.rb
@@ -40,7 +40,7 @@ module CachedResource
       # Re/send the request to fetch the resource
       def find_via_reload(key, *arguments)
         object = find_without_cache(*arguments)
-        return object unless cached_resource.enabled
+        return object unless should_cache?(object)
 
         cache_collection_synchronize(object, *arguments) if cached_resource.collection_synchronize
         return object if !cached_resource.cache_collections && is_any_collection?(*arguments)
@@ -77,6 +77,12 @@ module CachedResource
           updates.each { |object| index[object.send(primary_key)] = object }
           cache_write(cache_key(cached_resource.collection_arguments), index.values, *arguments)
         end
+      end
+
+      # Avoid cache nil or [] objects
+      def should_cache?(object)
+        return false unless cached_resource.enabled
+        object.respond_to?(:empty?) ? !object.empty? : !!object
       end
 
       # Determine if the given arguments represent

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -33,6 +33,7 @@ describe CachedResource do
     @other_string_thing_json = @other_string_thing.to_json
     @date_thing_json = @date_thing.to_json
     @nil_thing = nil.to_json
+    @empty_array_thing = [].to_json
     @not_the_thing = {:not_the_thing => {:id => 1, :name => "Not"}}
     @not_the_thing_json = @not_the_thing.to_json
   end
@@ -59,6 +60,7 @@ describe CachedResource do
         mock.get "/things/1.json?foo=bar", {}, @thing_json
         mock.get "/things/fded.json", {}, @string_thing_json
         mock.get "/things.json?name=42", {}, @nil_thing, 404
+        mock.get "/things.json?name=43", {}, @empty_array_thing
         mock.get "/things/4.json", {}, @date_thing_json
         mock.get "/not_the_things/1.json", {}, @not_the_thing_json
       end
@@ -66,13 +68,17 @@ describe CachedResource do
 
     it "should cache a response" do
       result = Thing.find(1)
-
       read_from_cache("thing/1").should == result
     end
 
-    it "should cache a nil response" do
+    it "shouldn't cache nil response" do
       result = Thing.find(:all, :params => { :name => '42' })
       read_from_cache("thing/all/name/42").should == nil
+    end
+
+    it "shouldn't cache [] response" do
+      result = Thing.find(:all, :params => { :name => '43' })
+      read_from_cache("thing/all/name/43").should == nil
     end
 
     it "should cache a response for a string primary key" do

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -72,13 +72,17 @@ describe CachedResource do
     end
 
     it "shouldn't cache nil response" do
-      result = Thing.find(:all, :params => { :name => '42' })
+      Thing.find(:all, :params => { :name => '42' })
       read_from_cache("thing/all/name/42").should == nil
+      result = Thing.find(1)
+      read_from_cache("thing/1").should == result
     end
 
     it "shouldn't cache [] response" do
-      result = Thing.find(:all, :params => { :name => '43' })
+      Thing.find(:all, :params => { :name => '43' })
       read_from_cache("thing/all/name/43").should == nil
+      result = Thing.find(1)
+      read_from_cache("thing/1").should == result
     end
 
     it "should cache a response for a string primary key" do

--- a/spec/cached_resource/caching_spec.rb
+++ b/spec/cached_resource/caching_spec.rb
@@ -74,15 +74,11 @@ describe CachedResource do
     it "shouldn't cache nil response" do
       Thing.find(:all, :params => { :name => '42' })
       read_from_cache("thing/all/name/42").should == nil
-      result = Thing.find(1)
-      read_from_cache("thing/1").should == result
     end
 
     it "shouldn't cache [] response" do
       Thing.find(:all, :params => { :name => '43' })
       read_from_cache("thing/all/name/43").should == nil
-      result = Thing.find(1)
-      read_from_cache("thing/1").should == result
     end
 
     it "should cache a response for a string primary key" do


### PR DESCRIPTION
# ISSUE 62
Resolves [#62](https://github.com/mhgbrown/cached_resource/issues/62)

## Changes 
Refactor `find_via_reload(key, *arguments)`
- To avoid cache `nil` or `[]` responses/objects
- Also refactor rspecs

## Test results
<img width="755" alt="Screenshot 2024-03-21 at 11 14 31" src="https://github.com/mhgbrown/cached_resource/assets/121519106/466ad0bc-447e-4670-a78c-f3a726edd4d2">
